### PR TITLE
Add Trafford dataset notebook generation

### DIFF
--- a/trafford_map.ipynb
+++ b/trafford_map.ipynb
@@ -1,0 +1,63 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# House Price Map\n",
+        "\n",
+        "This notebook loads property transaction data from the Land Registry CSV,\n",
+        "geocodes the postcodes to latitude/longitude and plots them on a map using Folium.\n",
+        "Marker colours indicate relative price bands. Click a marker to see details about the property."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "# Install dependencies if running in a fresh environment\nimport sys, subprocess\nfor pkg in ['pandas','folium','pgeocode','numpy','matplotlib']:\n    if pkg not in sys.modules:\n        try:\n            __import__(pkg)\n        except ImportError:\n            subprocess.check_call([sys.executable, '-m', 'pip', 'install', pkg])\n"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "import pandas as pd\nimport folium\nfrom folium.plugins import HeatMapWithTime, MarkerCluster, Fullscreen\nimport pgeocode\nimport numpy as np\nimport matplotlib.pyplot as plt\n"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "# Load the CSV file\ncolumns = ['transaction_id','price','date','postcode','property_type','old_new','duration','paon','saon','street','locality','town','district','county','ppd_cat','record_status']\ndf = pd.read_csv('trafford prices.csv', header=None, names=columns)\ndf['price'] = df['price'].astype(float)\ndf['date'] = pd.to_datetime(df['date'])\n\n# Geocode postcodes\nnomi = pgeocode.Nominatim('gb')\ndf[['lat','lon']] = df['postcode'].apply(lambda x: nomi.query_postal_code(x)[['latitude','longitude']])\ndf = df.dropna(subset=['lat','lon'])\n\n# Bin prices into 5 quantiles\nquantiles = pd.qcut(df['price'], 5, labels=False)\ncolours = ['blue','green','yellow','orange','red']\ndf['colour'] = quantiles.apply(lambda x: colours[int(x)])\n\nlegend_html = '''<div style=\"position: fixed; bottom: 50px; left: 50px; width: 150px;\nheight: 130px; border:2px solid grey; background-color:white; z-index:9999; font-size:14px;\">\n&nbsp;<b>Price Range</b><br>\n&nbsp;<i style=\"background:blue;\">&nbsp;&nbsp;&nbsp;&nbsp;</i>&nbsp;Lowest<br>\n&nbsp;<i style=\"background:green;\">&nbsp;&nbsp;&nbsp;&nbsp;</i><br>\n&nbsp;<i style=\"background:yellow;\">&nbsp;&nbsp;&nbsp;&nbsp;</i><br>\n&nbsp;<i style=\"background:orange;\">&nbsp;&nbsp;&nbsp;&nbsp;</i><br>\n&nbsp;<i style=\"background:red;\">&nbsp;&nbsp;&nbsp;&nbsp;</i>&nbsp;Highest\n</div>'''\n\ndef create_map(data):\n    m = folium.Map(location=[data['lat'].mean(), data['lon'].mean()], zoom_start=10)\n    Fullscreen().add_to(m)\n    marker_cluster = MarkerCluster().add_to(m)\n    for _, row in data.iterrows():\n        popup_text = f\"{row['street']} {row['postcode']}<br>\u00a3{row['price']:,}<br>{row['date'].date()}\"\n        folium.CircleMarker(\n            location=[row['lat'], row['lon']],\n            radius=5,\n            color=row['colour'],\n            fill=True,\n            fill_color=row['colour'],\n            popup=folium.Popup(popup_text, max_width=250)\n        ).add_to(marker_cluster)\n    m.get_root().html.add_child(folium.Element(legend_html))\n    return m\n\nm = create_map(df)\nm.save(os.path.splitext(output_notebook)[0] + '.html')\nm\n"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "# Heatmap with timeline slider\ndf['year_month'] = df['date'].dt.to_period('M')\ntime_index = sorted(df['year_month'].unique().astype(str))\nheat_data = []\nfor period in time_index:\n    subset = df[df['year_month'] == period]\n    heat_data.append(subset[['lat','lon','price']].values.tolist())\n\nm_heat = folium.Map(location=[df['lat'].mean(), df['lon'].mean()], zoom_start=10)\nHeatMapWithTime(heat_data, index=time_index, auto_play=False, max_opacity=0.7).add_to(m_heat)\nm_heat\n"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "# Line graph showing average monthly price trend\ndf_monthly = df.set_index('date').resample('M')['price'].mean()\nax = df_monthly.plot(marker='o', figsize=(8,4))\nax.set_ylabel('Average Price (\u00a3)')\nax.set_title('Average Property Price Over Time')\nax.figure\n"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- parameterize CSV and output path in `generate_notebook.py`
- include map UI improvements with `MarkerCluster` and `Fullscreen`
- generate example notebook `trafford_map.ipynb`

## Testing
- `python generate_notebook.py --csv 'trafford prices.csv' --output trafford_map.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_687eb54038cc832c9160db76d44a8abd