### PR TITLE
Deploy map to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy map to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pandas folium pgeocode
+      - name: Build map site
+        run: python map_website.py
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ This project generates a mobile friendly web page showing property transactions 
 - Python 3 with the packages `pandas`, `folium` and `pgeocode` installed.
 
 ## Usage
-Run the script to build the website:
+Run the script to build the website locally:
 
 ```bash
 python map_website.py
 ```
 
 This loads the data from `trafford prices.csv`, geocodes the postcodes and creates `site/index.html` with the map. Open this file in a web browser (desktop or mobile) to view and interact with the map. You can zoom and pan around the data points.
+
+## GitHub Pages
+
+The repository includes a workflow that automatically runs `map_website.py` and
+publishes the contents of the `site/` directory to GitHub Pages whenever changes
+are pushed to the `main` branch. After pushing, visit your repository's Pages
+URL to see the interactive map online.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy the map
- document deployment in the README

## Testing
- `python -m py_compile map_website.py`

------
https://chatgpt.com/codex/tasks/task_e_687ec7dc01a4832c9038112819b61dfa