### PR TITLE
Add Manchester borough price change notebook

### DIFF
--- a/manchester_borough_price_change.ipynb
+++ b/manchester_borough_price_change.ipynb
@@ -1,0 +1,41 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Manchester Borough Price Change Map\n",
+        "\n",
+        "This notebook loads `manc_data.csv`, calculates average house prices for 2024 and 2025 for each Greater Manchester borough,\n",
+        "and displays a map with borough markers coloured green for an increase in price and red for a decrease."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "# Install pandas and folium if needed\nimport sys, subprocess\nfor pkg in ['pandas', 'folium']:\n    try:\n        __import__(pkg)\n    except ImportError:\n        subprocess.check_call([sys.executable, '-m', 'pip', 'install', pkg])\n"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "import pandas as pd\nimport folium\n\n# Approximate borough centre coordinates\nborough_coords = {\n    'BOLTON': (53.5769, -2.4283),\n    'BURY': (53.5933, -2.2990),\n    'MANCHESTER': (53.4808, -2.2426),\n    'OLDHAM': (53.5405, -2.1183),\n    'ROCHDALE': (53.6160, -2.1550),\n    'SALFORD': (53.4890, -2.2901),\n    'STOCKPORT': (53.4084, -2.1493),\n    'TAMESIDE': (53.4800, -2.0800),\n    'TRAFFORD': (53.4280, -2.2920),\n    'WIGAN': (53.5450, -2.6370)\n}\n\ncols = ['transaction_id','price','date','postcode','property_type','old_new','duration','paon','saon','street','locality','town','district','county','ppd_cat','record']\ndf = pd.read_csv('manc_data.csv', names=cols, header=None)\n\ndf['price'] = df['price'].astype(float)\ndf['date'] = pd.to_datetime(df['date'])\ndf['year'] = df['date'].dt.year\n\navg = df.groupby(['district','year'])['price'].mean().unstack()\nchange = avg[2025] - avg[2024]\n\nmap_center = [53.4808, -2.2426]\nm = folium.Map(location=map_center, zoom_start=10)\nfor borough, diff in change.dropna().items():\n    lat, lon = borough_coords.get(borough.upper(), map_center)\n    colour = 'green' if diff > 0 else 'red'\n    folium.CircleMarker(\n        location=[lat, lon],\n        radius=10,\n        color=colour,\n        fill=True,\n        fill_color=colour,\n        popup=f'{borough}: {diff:+.2f}'\n    ).add_to(m)\n\nm"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- create `manchester_borough_price_change.ipynb` notebook
- notebook reads `manc_data.csv` to compute 2024-2025 average price changes for each borough
- uses folium to map boroughs with green/red markers for increase/decrease

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f48e66f70832ca0c5269291efbf24