### PR TITLE
Add Manchester area price change notebook

### DIFF
--- a/manchester_area_price_change.ipynb
+++ b/manchester_area_price_change.ipynb
@@ -1,0 +1,39 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Manchester Area Price Change Map\n",
+        "\n",
+        "This notebook reads `manc_data.csv` and computes the percentage change in average house price from 2024 to 2025 for each Manchester postcode area (e.g. M11, M12). The map shades each area green for increases and red for decreases with darker shades indicating larger changes. Clicking a marker shows the exact change and percentage."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "# Install pandas, folium and pgeocode if needed\nimport sys, subprocess\nfor pkg in ['pandas','folium','pgeocode']:\n    try:\n        __import__(pkg)\n    except ImportError:\n        subprocess.check_call([sys.executable, '-m', 'pip', 'install', pkg])"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "import pandas as pd\nimport folium\nimport pgeocode\nimport ipywidgets as widgets\nfrom IPython.display import display\n\ncols=['transaction_id','price','date','postcode','property_type','old_new','duration','paon','saon','street','locality','town','district','county','ppd_cat','record']\ndf=pd.read_csv('manc_data.csv',names=cols,header=None)\ndf['price']=df['price'].astype(float)\ndf['date']=pd.to_datetime(df['date'])\ndf['year']=df['date'].dt.year\ndf['prefix']=df['postcode'].str.split().str[0]\n\nyears=sorted(df['year'].unique())\n\nnomi=pgeocode.Nominatim('gb')\ncoord=df.groupby('prefix')['postcode'].first().to_dict()\nprefix_coords={p:(nomi.query_postal_code(pc)['latitude'],nomi.query_postal_code(pc)['longitude']) for p,pc in coord.items()}\n\nincrease_start=(144,238,144)\nincrease_end=(0,100,0)\ndecrease_start=(255,204,204)\ndecrease_end=(139,0,0)\n\ndef interp(start,end,ratio):\n    r=int(start[0]+(end[0]-start[0])*ratio)\n    g=int(start[1]+(end[1]-start[1])*ratio)\n    b=int(start[2]+(end[2]-start[2])*ratio)\n    return f'#{r:02x}{g:02x}{b:02x}'\n\ndef trimmed_mean(series):\n    if series.empty:\n        return None\n    q_low=series.quantile(0.1)\n    q_high=series.quantile(0.9)\n    trimmed=series[(series>=q_low)&(series<=q_high)]\n    return trimmed.mean() if not trimmed.empty else None\n\ndef create_map(y1,y2):\n    avg=df.groupby(['prefix','year'])['price'].apply(trimmed_mean).unstack()\n    change=avg[y2]-avg[y1]\n    percent=((avg[y2]-avg[y1])/avg[y1])*100\n    inc_max=percent.max()\n    dec_min=percent.min()\n    m=folium.Map(location=[53.4808,-2.2426],zoom_start=10)\n    for area,pct in percent.dropna().items():\n        lat,lon=prefix_coords.get(area,[53.4808,-2.2426])\n        diff=change.get(area,0)\n        if pct>=0:\n            ratio=0 if inc_max==0 else pct/inc_max\n            colour=interp(increase_start,increase_end,ratio)\n        else:\n            ratio=0 if dec_min==0 else pct/dec_min\n            colour=interp(decrease_start,decrease_end,ratio)\n        folium.CircleMarker(\n            location=[lat,lon],\n            radius=8,\n            color=colour,\n            fill=True,\n            fill_color=colour,\n            popup=f'{area}: {diff:+.0f} ({pct:+.2f}%)'\n        ).add_to(m)\n    return m\n\nyear1=widgets.Dropdown(options=years,description='Year 1',value=years[0])\nyear2=widgets.Dropdown(options=years,description='Year 2',value=years[-1])\nout=widgets.Output()\n\ndef update(change=None):\n    with out:\n        out.clear_output()\n        display(create_map(year1.value,year2.value))\n\nyear1.observe(update,'value')\nyear2.observe(update,'value')\ndisplay(widgets.VBox([widgets.HBox([year1,year2]),out]))\nupdate()\n"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/manchester_borough_price_change.ipynb
+++ b/manchester_borough_price_change.ipynb
@@ -1,0 +1,41 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Manchester Borough Price Change Map\n",
+        "\n",
+        "This notebook loads `manc_data.csv`, calculates average house prices for 2024 and 2025 for each Greater Manchester borough,\n",
+        "and displays a map with borough markers coloured green for an increase in price and red for a decrease."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "# Install pandas and folium if needed\nimport sys, subprocess\nfor pkg in ['pandas', 'folium']:\n    try:\n        __import__(pkg)\n    except ImportError:\n        subprocess.check_call([sys.executable, '-m', 'pip', 'install', pkg])\n"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "import pandas as pd\nimport folium\n\n# Approximate borough centre coordinates\nborough_coords = {\n    'BOLTON': (53.5769, -2.4283),\n    'BURY': (53.5933, -2.2990),\n    'MANCHESTER': (53.4808, -2.2426),\n    'OLDHAM': (53.5405, -2.1183),\n    'ROCHDALE': (53.6160, -2.1550),\n    'SALFORD': (53.4890, -2.2901),\n    'STOCKPORT': (53.4084, -2.1493),\n    'TAMESIDE': (53.4800, -2.0800),\n    'TRAFFORD': (53.4280, -2.2920),\n    'WIGAN': (53.5450, -2.6370)\n}\n\ncols = ['transaction_id','price','date','postcode','property_type','old_new','duration','paon','saon','street','locality','town','district','county','ppd_cat','record']\ndf = pd.read_csv('manc_data.csv', names=cols, header=None)\n\ndf['price'] = df['price'].astype(float)\ndf['date'] = pd.to_datetime(df['date'])\ndf['year'] = df['date'].dt.year\n\navg = df.groupby(['district','year'])['price'].mean().unstack()\nchange = avg[2025] - avg[2024]\n\nmap_center = [53.4808, -2.2426]\nm = folium.Map(location=map_center, zoom_start=10)\nfor borough, diff in change.dropna().items():\n    lat, lon = borough_coords.get(borough.upper(), map_center)\n    colour = 'green' if diff > 0 else 'red'\n    folium.CircleMarker(\n        location=[lat, lon],\n        radius=10,\n        color=colour,\n        fill=True,\n        fill_color=colour,\n        popup=f'{borough}: {diff:+.2f}'\n    ).add_to(m)\n\nm"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- create `manchester_area_price_change.ipynb` for postcode-level analysis
- compute 2024-2025 percent price change
- shade map markers green/red with intensity by percent change and show diff in popup
- add interactive dropdowns to choose available years and exclude top/bottom 10% per area

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687f48e66f70832ca0c5269291efbf24