### PR TITLE
Add cluster price change notebook

### DIFF
--- a/manchester_cluster_price_change.ipynb
+++ b/manchester_cluster_price_change.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Manchester Cluster Price Change Map\n",
+    "\n",
+    "This notebook reads `2019_to_today_manc.csv`, clusters the sales data into geographic groups smaller than boroughs, and calculates the percentage change in average house price from 2020 to 2024 for each cluster. Outliers are removed by dropping the top and bottom 10% of transactions by price. A Folium map overlaying Manchester with a topographic basemap colours each cluster green for price increases and red for decreases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Install required packages if missing\nimport sys, subprocess\nfor pkg in ['pandas','folium','pgeocode','scikit-learn']:\n    try:\n        __import__(pkg)\n    except ImportError:\n        subprocess.check_call([sys.executable, '-m', 'pip', 'install', pkg])"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import pandas as pd\nimport numpy as np\nimport folium\nfrom folium.plugins import Fullscreen\nimport pgeocode\nfrom sklearn.cluster import KMeans"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Load dataset"\
+"\ncols = ['transaction_id','price','date','postcode','property_type','old_new','duration','paon','saon','street','locality','town','district','county','ppd_category','record_status']\ndf = pd.read_csv('2019_to_today_manc.csv', header=None, names=cols)\ndf['price'] = df['price'].astype(float)\ndf['date'] = pd.to_datetime(df['date'])"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Filter for 2020-2024 and drop outliers\nmask = (df['date'].dt.year >= 2020) & (df['date'].dt.year <= 2024)\ndf = df[mask]\ndf = df.sort_values('price')\nq1 = int(len(df) * 0.1)\nq9 = int(len(df) * 0.9)\ndf = df.iloc[q1:q9].copy()"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Geocode postcodes to lat/lon\nnomi = pgeocode.Nominatim('gb')\ndf[['lat','lon']] = df['postcode'].apply(lambda x: nomi.query_postal_code(x)[['latitude','longitude']])\ndf = df.dropna(subset=['lat','lon'])"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Cluster points using KMeans into 20 groups\ncoords = df[['lat','lon']]\nkm = KMeans(n_clusters=20, random_state=0).fit(coords)\ndf['cluster'] = km.labels_"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Calculate percentage change from 2020 to 2024 for each cluster\ndf['year'] = df['date'].dt.year\nsummary = df[df['year'].isin([2020,2024])].groupby(['cluster','year'])['price'].mean().unstack()\nsummary['pct_change'] = (summary[2024] - summary[2020]) / summary[2020] * 100\nsummary = summary.dropna(subset=['pct_change'])"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Map setup with topographic tiles\ncolor_scale = summary['pct_change']\nmin_change = color_scale.min()\nmax_change = color_scale.max()\n\ncolormap = folium.LinearColormap(['red','white','green'], vmin=min_change, vmax=max_change)\n\ncentre = [df['lat'].mean(), df['lon'].mean()]\nmap_manchester = folium.Map(location=centre, zoom_start=11, tiles='Stamen Terrain', control_scale=True)\nFullscreen().add_to(map_manchester)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Add clusters to map\nfor cluster_id, row in summary.iterrows():\n    cluster_points = df[df['cluster'] == cluster_id]\n    lat = cluster_points['lat'].mean()\n    lon = cluster_points['lon'].mean()\n    change = row['pct_change']\n    colour = colormap(change)\n    folium.CircleMarker(\n        location=[lat, lon],\n        radius=15,\n        color=colour,\n        fill=True,\n        fill_color=colour,\n        fill_opacity=0.7,\n        popup=f'Cluster {cluster_id}<br>{change:.2f}% change'\n    ).add_to(map_manchester)\n\ncolormap.caption = '% change in average price 2020-2024'\nmap_manchester.add_child(colormap)\nmap_manchester"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- create new notebook `manchester_cluster_price_change.ipynb`
- notebook loads `2019_to_today_manc.csv`, clusters properties, and maps percentage change in average price from 2020 to 2024 with a topographic background

## Testing
- `python -m py_compile map_website.py generate_notebook.py`

------
https://chatgpt.com/codex/tasks/task_e_6881f79e60dc832c9f59eb3d9dd2007e